### PR TITLE
Framework: added vuejs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@
 
 - 🎥&nbsp;&nbsp;[NextJS](https://www.udemy.com/course/nextjs-react-the-complete-guide/)
 - 🎥&nbsp;&nbsp;[Angular](https://www.udemy.com/course/the-complete-guide-to-angular-2/)
-- 🎥&nbsp;&nbsp;[Vue:Complete guide](https://www.udemy.com/course/vuejs-2-the-complete-guide/)
+- 🎥&nbsp;&nbsp;[Vue2:Complete guide](https://www.udemy.com/course/vuejs-2-the-complete-guide/)
+- 🎥&nbsp;&nbsp;[Vue3:Official guide](https://vuejs.org/guide/introduction.html)
+- 🎥&nbsp;&nbsp;[Vue Mastery: VUE courses from VUE creators](https://www.vuemastery.com/)
+- 🎥&nbsp;&nbsp;[Vue Mastery: Learning paths](https://www.vuemastery.com/learning-path/beginner)
 - 🎥&nbsp;&nbsp;[Sveltejs: Complete Guide](https://www.udemy.com/course/sveltejs-the-complete-guide/)
 
 <br>

--- a/README.md
+++ b/README.md
@@ -135,8 +135,6 @@
 - 🎥&nbsp;&nbsp;[Angular](https://www.udemy.com/course/the-complete-guide-to-angular-2/)
 - 🎥&nbsp;&nbsp;[Vue2:Complete guide](https://www.udemy.com/course/vuejs-2-the-complete-guide/)
 - 🎥&nbsp;&nbsp;[Vue3:Official guide](https://vuejs.org/guide/introduction.html)
-- 🎥&nbsp;&nbsp;[Vue Mastery: VUE courses from VUE creators](https://www.vuemastery.com/)
-- 🎥&nbsp;&nbsp;[Vue Mastery: Learning paths](https://www.vuemastery.com/learning-path/beginner)
 - 🎥&nbsp;&nbsp;[Sveltejs: Complete Guide](https://www.udemy.com/course/sveltejs-the-complete-guide/)
 
 <br>


### PR DESCRIPTION
Vue2 EOL is Dec'22. 
Devs specially juniors should focus on learning Vue3 and vue2 just if they need to work in legacy code.